### PR TITLE
V3.3.2

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -20,6 +20,20 @@ authors:
   given-names: Mathieu
   email: mathieu@mgravey.com
   orcid: https://orcid.org/0000-0002-0871-1507
+preferred-citation:
+  type: manual
+  title: 'GeoPressureR: Global positioning by atmospheric pressure'
+  authors:
+  - family-names: Nussbaumer
+    given-names: Raphael
+    email: rafnuss@gmail.com
+    orcid: https://orcid.org/0000-0002-8185-1020
+  - family-names: Gravey
+    given-names: Mathieu
+    email: mathieu@mgravey.com
+    orcid: https://orcid.org/0000-0002-0871-1507
+  url: https://github.com/Rafnuss/GeoPressureR
+  year: '2022'
 repository-code: https://github.com/Rafnuss/GeoPressureR
 url: https://raphaelnussbaumer.com/GeoPressureR/
 contact:
@@ -38,6 +52,63 @@ keywords:
 - tracker
 - windspeed
 references:
+- type: article
+  title: Global positioning with animal-borne pressure sensors
+  authors:
+  - family-names: Nussbaumer
+    given-names: Raphael
+    email: rafnuss@gmail.com
+    orcid: https://orcid.org/0000-0002-8185-1020
+  - family-names: Gravey
+    given-names: Mathieu
+    email: mathieu@mgravey.com
+    orcid: https://orcid.org/0000-0002-0871-1507
+  - family-names: Briedis
+    given-names: Martins
+    email: martins.briedis@vogelwarte.ch
+    orcid: https://orcid.org/0000-0002-9434-9056
+  - family-names: Liechti
+    given-names: Felix
+    email: felix.liechti@vogelwarte.ch
+    orcid: https://orcid.org/0000-0001-9473-0837
+  doi: 10.1111/2041-210X.14043
+  url: https://doi.org/10.1111/2041-210X.14043
+  year: '2023'
+  journal: Methods in Ecology and Evolution
+  volume: '14'
+  issue: '4'
+  start: 1104-1117
+- type: article
+  title: Reconstructing bird trajectories from pressure and wind data using a highly
+    optimised hidden Markov model
+  authors:
+  - family-names: Nussbaumer
+    given-names: Raphael
+    email: rafnuss@gmail.com
+    orcid: https://orcid.org/0000-0002-8185-1020
+  - family-names: Gravey
+    given-names: Mathieu
+    email: mathieu@mgravey.com
+    orcid: https://orcid.org/0000-0002-0871-1507
+  - family-names: Briedis
+    given-names: Martins
+    email: martins.briedis@vogelwarte.ch
+    orcid: https://orcid.org/0000-0002-9434-9056
+  - family-names: Liechti
+    given-names: Felix
+    email: felix.liechti@vogelwarte.ch
+    orcid: https://orcid.org/0000-0001-9473-0837
+  - family-names: Sheldon
+    given-names: Daniel
+    orcid: https://orcid.org/0000-0002-4257-2432
+  doi: 10.1111/2041-210X.14082
+  url: https://doi.org/10.1111/2041-210X.14082
+  year: '2023'
+  journal: Methods in Ecology and Evolution
+  volume: '14'
+  issue: '4'
+  start: '1'
+  end: '32'
 - type: software
   title: 'R: A Language and Environment for Statistical Computing'
   notes: Depends

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,6 +9,7 @@ type: software
 license: GPL-3.0-or-later
 title: 'GeoPressureR: Global Positioning by Atmospheric Pressure'
 version: 3.3.2
+doi: 10.5281/zenodo.7754457
 abstract: R package to determine the position and trajectory of a bird based on light-weight
   data-logger measuring at lease atmospheric pressure.
 authors:
@@ -32,6 +33,7 @@ preferred-citation:
     given-names: Mathieu
     email: mathieu@mgravey.com
     orcid: https://orcid.org/0000-0002-0871-1507
+  doi: 10.5281/zenodo.7754457
   url: https://github.com/Rafnuss/GeoPressureR
   year: '2022'
 repository-code: https://github.com/Rafnuss/GeoPressureR
@@ -109,6 +111,20 @@ references:
   issue: '4'
   start: '1'
   end: '32'
+- type: manual
+  title: 'GeoPressureManual: Learn how to use GeoPressureR with examples.'
+  authors:
+  - family-names: Nussbaumer
+    given-names: Raphael
+    email: rafnuss@gmail.com
+    orcid: https://orcid.org/0000-0002-8185-1020
+  - family-names: Nussbaumer
+    given-names: Améline
+    email: ameline.nussbaumer@gmail.com
+    orcid: https://orcid.org/0000-0003-1308-4154
+  doi: 10.5281/zenodo.10799355
+  url: https://github.com/Rafnuss/GeoPressureManual
+  year: '2024'
 - type: software
   title: 'R: A Language and Environment for Statistical Computing'
   notes: Depends

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,8 +8,7 @@ message: 'To cite package "GeoPressureR" in publications use:'
 type: software
 license: GPL-3.0-or-later
 title: 'GeoPressureR: Global Positioning by Atmospheric Pressure'
-version: 3.3.1
-doi: 10.1111/2041-210X.14043
+version: 3.3.2
 abstract: R package to determine the position and trajectory of a bird based on light-weight
   data-logger measuring at lease atmospheric pressure.
 authors:
@@ -21,33 +20,6 @@ authors:
   given-names: Mathieu
   email: mathieu@mgravey.com
   orcid: https://orcid.org/0000-0002-0871-1507
-preferred-citation:
-  type: article
-  title: Global positioning with animal-borne pressure sensors
-  authors:
-  - family-names: Nussbaumer
-    given-names: Raphael
-    email: rafnuss@gmail.com
-    orcid: https://orcid.org/0000-0002-8185-1020
-  - family-names: Gravey
-    given-names: Mathieu
-    email: mathieu@mgravey.com
-    orcid: https://orcid.org/0000-0002-0871-1507
-  - family-names: Briedis
-    given-names: Martins
-    email: martins.briedis@vogelwarte.ch
-    orcid: https://orcid.org/0000-0002-9434-9056
-  - family-names: Liechti
-    given-names: Felix
-    email: felix.liechti@vogelwarte.ch
-    orcid: https://orcid.org/0000-0001-9473-0837
-  doi: 10.1111/2041-210X.14043
-  url: https://doi.org/10.1111/2041-210X.14043
-  year: '2023'
-  journal: Methods in Ecology and Evolution
-  volume: '14'
-  issue: '4'
-  start: 1104-1117
 repository-code: https://github.com/Rafnuss/GeoPressureR
 url: https://raphaelnussbaumer.com/GeoPressureR/
 contact:
@@ -66,50 +38,6 @@ keywords:
 - tracker
 - windspeed
 references:
-- type: article
-  title: Reconstructing bird trajectories from pressure and wind data using a highly
-    optimised hidden Markov model
-  authors:
-  - family-names: Nussbaumer
-    given-names: Raphael
-    email: rafnuss@gmail.com
-    orcid: https://orcid.org/0000-0002-8185-1020
-  - family-names: Gravey
-    given-names: Mathieu
-    email: mathieu@mgravey.com
-    orcid: https://orcid.org/0000-0002-0871-1507
-  - family-names: Briedis
-    given-names: Martins
-    email: martins.briedis@vogelwarte.ch
-    orcid: https://orcid.org/0000-0002-9434-9056
-  - family-names: Liechti
-    given-names: Felix
-    email: felix.liechti@vogelwarte.ch
-    orcid: https://orcid.org/0000-0001-9473-0837
-  - family-names: Sheldon
-    given-names: Daniel
-    orcid: https://orcid.org/0000-0002-4257-2432
-  doi: 10.1111/2041-210X.14082
-  url: https://doi.org/10.1111/2041-210X.14082
-  year: '2023'
-  journal: Methods in Ecology and Evolution
-  volume: '14'
-  issue: '4'
-  start: '1'
-  end: '32'
-- type: manual
-  title: 'GeoPressureR: Global positioning by atmospheric pressure'
-  authors:
-  - family-names: Nussbaumer
-    given-names: Raphael
-    email: rafnuss@gmail.com
-    orcid: https://orcid.org/0000-0002-8185-1020
-  - family-names: Gravey
-    given-names: Mathieu
-    email: mathieu@mgravey.com
-    orcid: https://orcid.org/0000-0002-0871-1507
-  url: https://github.com/Rafnuss/GeoPressureR
-  year: '2022'
 - type: software
   title: 'R: A Language and Environment for Statistical Computing'
   notes: Depends

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: GeoPressureR
 Title: Global Positioning by Atmospheric Pressure
-Version: 3.3.1
+Version: 3.3.2
 Authors@R: c(
     person("Raphaël", "Nussbaumer", , "rafnuss@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-8185-1020")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,39 @@
+# GeoPressureR v3.3.2
+
+## Major update
+* Change the computation of distance of edges in the graph by removing the fix that added 1 resolution to the distance to account for large grid square and short flight distance. Instead, add warning message in case there might be such an issue (flight distance < grid resolution) [ddbd07d](https://github.com/Rafnuss/GeoPressureR/pull/126/commits/ddbd07db195440005f7f1ff96dd134dd43bdd8ae). 
+* Add `zero_speed_threshold` parameter that allow to encourage bird to stay at the same location. This is typically the case for short flight that don't seems to affect the position. Quite similar to a `stap_elev` [2060790](https://github.com/Rafnuss/GeoPressureR/pull/126/commits/2060790f8508c447a00877c2fc1d86c9d52bfe2e)
+* Add other type of pressurepath in interim [8d7f1d1](https://github.com/Rafnuss/GeoPressureR/pull/126/commits/8d7f1d12665608d37f5eafa53fb251554e7f5cdd)
+
+## Minor
+* Plenty of small fixes and minor improvements [834155e](https://github.com/Rafnuss/GeoPressureR/pull/126/commits/834155eeffcf04b33effce8d9b9d193c5554cbdf), [152c6e7](https://github.com/Rafnuss/GeoPressureR/pull/126/commits/152c6e7a2091970b444a47a3ceb0a367a42a9c2a), [54aa995](https://github.com/Rafnuss/GeoPressureR/pull/126/commits/54aa99589f8e709089a08ae02c5aace821ab7cea),  [3a5ff95](https://github.com/Rafnuss/GeoPressureR/pull/126/commits/3a5ff95774b353c853a32ed63327dad8df82fbbe), [6eedd83](https://github.com/Rafnuss/GeoPressureR/pull/126/commits/6eedd83802f9377db43cba06c2e4b684b2154452), [8797533](https://github.com/Rafnuss/GeoPressureR/pull/126/commits/8797533b49c9cc76a3d81a90824a8ceaabd48692), [1e68260](https://github.com/Rafnuss/GeoPressureR/pull/126/commits/1e68260c39bc49816c95095d0f3c3541986a50df)
+
+**Full Changelog**: https://github.com/Rafnuss/GeoPressureR/compare/v3.3.1...v3.3.2
+
+
+# GeoPressureR v3.3.1
+
+## Major update
+* [Update of param structure to function_name$param_name](https://github.com/Rafnuss/GeoPressureR/commit/2235e9ec0bceef3b49d8e1887a309b2048353552). The structure of the param has been reorganised: this named list stored inside of tag and graph stores parameters used during the building of tag and graph. We standardized this structure as param${function_name}${argument_name}. [See the migration instructions in the GeoPressureR wiki](https://github.com/Rafnuss/GeoPressureR/wiki/Migration-v3.x-%E2%80%90--v3.3). This will mean you'll need to update your config.yml structure - sorry for that.
+* [Add geopressuretemplate() functions](https://github.com/Rafnuss/GeoPressureR/commit/b000764ff3c2179eefb48bbf9178c5323c89aa7d). The main improvement is related to the use of a single function to run the entire workflow: geopressuretemplate. Read more about this in the [corresponding chapter of the GeoPressureManual](https://raphaelnussbaumer.com/GeoPressureManual/geopressuretemplate-workflow.html).
+
+## Minor
+* [replace species_name by scientific_name](https://github.com/Rafnuss/GeoPressureR/commit/5e1b15fd025f355107a90229779969ad2030d7c7)
+* [crop date UTC](https://github.com/Rafnuss/GeoPressureR/commit/0707ae6041383bff704a4c78511ab2dbd16305ce)
+* [fix new variable name in netcdf](https://github.com/Rafnuss/GeoPressureR/commit/6c12362128c569c05ae49bb0ed40b8a31adc5980)
+
+## New Contributors
+* @PabloCapilla made their first contribution in https://github.com/Rafnuss/GeoPressureR/pull/125
+
+**Full Changelog**: https://github.com/Rafnuss/GeoPressureR/compare/v3.3.0...v3.3.1
+
 # GeoPressureR v3.3
 
 ## Major
 - Read all sensors type and allow reading sensor without pressure `assert_pressure = FALSE` (https://github.com/Rafnuss/GeoPressureR/pull/123/commits/d11f8cc4774b4c91c27318c43d438823b681066e, https://github.com/Rafnuss/GeoPressureR/pull/123/commits/85ffe940ec46af8cd56592c2d641f25d19712129)
-- [Update to ecmwfr v2. Change to cds_token](https://github.com/Rafnuss/GeoPressureR/pull/123/commits/4253e04f9ed16e3b06d45edfda0b2a0900d31d0c)
-- [Improvement of tag_label_auto() with post-processing step](https://github.com/Rafnuss/GeoPressureR/commit/69c26adf559fc1bc7c2690346de41f6732f9eda5)
-- [Create path2twilight.R](https://github.com/Rafnuss/GeoPressureR/commit/eff97315c5eca3dff03736e7d40efad30b209819) and [Add twilight_line in plot_twilight](https://github.com/Rafnuss/GeoPressureR/commit/b21aa06ceff257ec4473a3af530a8ba7cef5e225)
+- [Update to ecmwfr v2. Change to cds_token](https://github.com/Rafnuss/GeoPressureR/pull/123/commits/4253e04f9ed16e3b06d45edfda0b2a0900d31d0c). We use the Climate Data Store to download the wind data during the flight. They have recently [updated their infrastructure](https://confluence.ecmwf.int/display/CKB/Please+read%3A+CDS+and+ADS+migrating+to+new+infrastructure%3A+Common+Data+Store+%28CDS%29+Engine) and their login procedure has changed. You’ll need an ECMF login with an Access Token. See updated procedure in the chapter [Trajectory with wind of the GeoPressureManual](https://raphaelnussbaumer.com/GeoPressureManual/trajectory-with-wind.html#download-wind-data).
+- [Improvement of tag_label_auto() with post-processing step](https://github.com/Rafnuss/GeoPressureR/commit/69c26adf559fc1bc7c2690346de41f6732f9eda5). Based on a simple classification of prolonged high activity, migratory flight classification was often not very performant, e.g. when a bird was gliding during the flight. I have now added a post-processing step in the automatic classification to fix this. Read more in [the detail section of tag_label_auto().](https://raphaelnussbaumer.com/GeoPressureR/reference/tag_label_auto.html#details).
+- [Create path2twilight.R](https://github.com/Rafnuss/GeoPressureR/commit/eff97315c5eca3dff03736e7d40efad30b209819) and [Add twilight_line in plot_twilight](https://github.com/Rafnuss/GeoPressureR/commit/b21aa06ceff257ec4473a3af530a8ba7cef5e225). You can now compute the theoretical twilight of a path, or more interestingly, of a pressurepath. It's also used in [pressurepath_create()](https://raphaelnussbaumer.com/GeoPressureR/reference/pressurepath_create.html), returning a column with sunrise and sunset. Its original purpose was to be able to check the twilight labeling by comparing it to a path generated, e.g., with GeoPressureviz. See the [last section of the light map chapter](https://raphaelnussbaumer.com/GeoPressureManual/light-map.html#check-light-label) for more info.
 
 ## Minor:
 - [Fix issue with tag_plot_twilight() when twilight was not yet computed](https://github.com/Rafnuss/GeoPressureR/pull/123/commits/6de3af2a97e27763c5a70a0e570c91921b699f01)

--- a/R/bird_create.R
+++ b/R/bird_create.R
@@ -45,14 +45,18 @@ bird_create <- function(scientific_name,
   }
   if (is.null(mass) || (is.null(wing_aspect) + is.null(wing_area) + is.null(wing_span) > 1)) {
     # Mass, wing length and secondary length are retrieve from the AVONET
-    sp_id <- grep(scientific_name, avonet$species, ignore.case = TRUE)
+    sp_id <- grep(scientific_name, GeoPressureR:::avonet$species, ignore.case = FALSE, fixed = TRUE)
     if (length(sp_id) == 0) {
-      cli::cli_abort("No match for {.val scientific_name}. Please use the exact scientific name.
-                      Closest matches are:
-                      {avonet$species[agrep(scientific_name, avonet$species, ignore.case = TRUE)]}")
-    } else if (length(sp_id) > 1) {
-      cli::cli_abort("Multiple match for {.val scientific_name}. Please use the exact scientific
-      name. {avonet$species[sp_id]}")
+      sp_id <- grep(scientific_name, avonet$species, ignore.case = TRUE)
+      if (length(sp_id) == 0) {
+        cli::cli_abort(
+          "No match for {.val scientific_name}. Please use the exact scientific name. Closest
+        matches are: {avonet$species[agrep(scientific_name, avonet$species, ignore.case = TRUE)]}"
+        )
+      } else if (length(sp_id) > 1) {
+        cli::cli_abort("Multiple match for {.val scientific_name}. Please use the exact scientific
+        name. {avonet$species[sp_id]}")
+      }
     }
     b <- avonet[sp_id, ]
     b$mass <- b$mass / 1000 # g -> kg

--- a/R/bird_create.R
+++ b/R/bird_create.R
@@ -45,7 +45,7 @@ bird_create <- function(scientific_name,
   }
   if (is.null(mass) || (is.null(wing_aspect) + is.null(wing_area) + is.null(wing_span) > 1)) {
     # Mass, wing length and secondary length are retrieve from the AVONET
-    sp_id <- grep(scientific_name, GeoPressureR:::avonet$species, ignore.case = FALSE, fixed = TRUE)
+    sp_id <- grep(scientific_name, avonet$species, ignore.case = FALSE, fixed = TRUE)
     if (length(sp_id) == 0) {
       sp_id <- grep(scientific_name, avonet$species, ignore.case = TRUE)
       if (length(sp_id) == 0) {

--- a/R/edge_add_wind.R
+++ b/R/edge_add_wind.R
@@ -510,16 +510,18 @@ edge_add_wind_check <- function(
       # Check if spatial extend match
       lat <- ncdf4::ncvar_get(nc, "latitude")
       lon <- ncdf4::ncvar_get(nc, "longitude")
+      nc_extent <- c(min(lon), max(lon), min(lat), max(lat))
       if (min(g$lat) < min(lat) || max(g$lat) > max(lat) ||
         min(g$lon) < min(lon) || max(g$lon) > max(lon)) {
-        cli::cli_abort(c(x = "Spatial extend not matching for {.file {file(i_s)}}"))
+        cli::cli_abort(c(x = "Spatial extend of the grid ({tag_graph$param$tag_set_map$extent}) is
+        not included in the extent of {.file {file(i_s)}} ({nc_extent})"))
       }
 
       # Check if flight duration is
       if (fl_s$start[i_fl] >= fl_s$end[i_fl]) {
         cli::cli_abort(c(
-          x = "Flight starting on stap {fl_s$stap_s[i_fl]} has a start time equal or greater than \\
-                         the end time. Please review your labelling file."
+          x = "Flight starting on stap {fl_s$stap_s[i_fl]} has a start time equal or greater than
+          the end time. Please review your labelling file."
         ))
       }
     }

--- a/R/edge_add_wind.R
+++ b/R/edge_add_wind.R
@@ -510,7 +510,7 @@ edge_add_wind_check <- function(
       # Check if spatial extend match
       lat <- ncdf4::ncvar_get(nc, "latitude")
       lon <- ncdf4::ncvar_get(nc, "longitude")
-      nc_extent <- c(min(lon), max(lon), min(lat), max(lat))
+      nc_extent <- c(min(lon), max(lon), min(lat), max(lat)) # nolint
       if (min(g$lat) < min(lat) || max(g$lat) > max(lat) ||
         min(g$lon) < min(lon) || max(g$lon) > max(lon)) {
         cli::cli_abort(c(x = "Spatial extend of the grid ({tag_graph$param$tag_set_map$extent}) is

--- a/R/geopressure_timeseries.R
+++ b/R/geopressure_timeseries.R
@@ -162,7 +162,7 @@ geopressure_timeseries <- function(lat,
 
   # Check for change in position
   if (resp_data$distInter > 0) {
-    cli::cli_inform(c("!" = "Requested position is on water and will be move to the closet point \\
+    cli::cli_bullets(c("!" = "Requested position is on water and will be move to the closet point \\
       on shore \\
       ({.url https://www.google.com/maps/dir/{lat},{lon}/{resp_data$lat},{resp_data$lon}}) \\
       located {round(resp_data$distInter / 1000)} km away."))

--- a/R/geopressuretemplate_graph.R
+++ b/R/geopressuretemplate_graph.R
@@ -80,7 +80,7 @@ geopressuretemplate_graph <- function(
       }
     },
     error = function(e) {
-      cli::cli_inform(c(
+      cli::cli_bullets(c(
         "x" = "{e$message}",
         "i" = "Error while defining the movement model.{.var graph} is return.",
         ">" = "Debug line by line by opening {.code edit(geopressuretemplate_graph)}"
@@ -132,7 +132,7 @@ geopressuretemplate_graph <- function(
       }
     },
     error = function(e) {
-      cli::cli_inform(c(
+      cli::cli_bullets(c(
         "x" = "{e$message}",
         "x" = "Error while computing the outputs. {.var graph} is returned.",
         ">" = "Debug line by line by opening {.code edit(geopressuretemplate_graph)}"
@@ -144,7 +144,7 @@ geopressuretemplate_graph <- function(
 
   dir_file <- dirname(file)
   if (!dir.exists(dir_file)) {
-    cli::cli_inform(c("!" = "The directory {.file {dir_file}} does not  exists."))
+    cli::cli_bullets(c("!" = "The directory {.file {dir_file}} does not  exists."))
     res <- utils::askYesNo("Do you want to create it?")
     if (res) {
       dir.create(dir_file)

--- a/R/geopressuretemplate_pressurepath.R
+++ b/R/geopressuretemplate_pressurepath.R
@@ -54,6 +54,32 @@ geopressuretemplate_pressurepath <- function(
       save_list <- c(save_list, "pressurepath_geopressureviz")
     }
 
+    if ("pressurepath_tag" %in% config$geopressuretemplate$pressurepath &&
+        "path_tag" %in% save_list) {
+      path_tag <- get("path_tag")
+      pressurepath_geopressureviz <- pressurepath_create( # nolint
+        tag,
+        path = path_tag,
+        variable = config$pressurepath_create$variable,
+        solar_dep = config$pressurepath_create$solar_dep,
+        quiet = quiet
+      )
+      save_list <- c(save_list, "pressurepath_tag")
+    }
+
+    if ("pressurepath_simulation" %in% config$geopressuretemplate$pressurepath &&
+        "path_simulation" %in% save_list) {
+      path_simulation <- get("path_tag")
+      pressurepath_geopressureviz <- pressurepath_create( # nolint
+        tag,
+        path = path_simulation,
+        variable = config$pressurepath_create$variable,
+        solar_dep = config$pressurepath_create$solar_dep,
+        quiet = quiet
+      )
+      save_list <- c(save_list, "pressurepath_simulation")
+    }
+
     # Save the outputs to the specified file
     save(
       list = save_list,

--- a/R/geopressuretemplate_pressurepath.R
+++ b/R/geopressuretemplate_pressurepath.R
@@ -55,7 +55,7 @@ geopressuretemplate_pressurepath <- function(
     }
 
     if ("pressurepath_tag" %in% config$geopressuretemplate$pressurepath &&
-        "path_tag" %in% save_list) {
+      "path_tag" %in% save_list) {
       path_tag <- get("path_tag")
       pressurepath_geopressureviz <- pressurepath_create( # nolint
         tag,
@@ -68,7 +68,7 @@ geopressuretemplate_pressurepath <- function(
     }
 
     if ("pressurepath_simulation" %in% config$geopressuretemplate$pressurepath &&
-        "path_simulation" %in% save_list) {
+      "path_simulation" %in% save_list) {
       path_simulation <- get("path_tag")
       pressurepath_geopressureviz <- pressurepath_create( # nolint
         tag,

--- a/R/geopressuretemplate_tag.R
+++ b/R/geopressuretemplate_tag.R
@@ -14,7 +14,7 @@ geopressuretemplate_tag <- function(
   # Check if folder exist
   dir_file <- dirname(file)
   if (!dir.exists(dir_file)) {
-    cli::cli_inform(c("!" = "The directory {.file {dir_file}} does not exists."))
+    cli::cli_bullets(c("!" = "The directory {.file {dir_file}} does not exists."))
     res <- utils::askYesNo("Do you want to create it?")
     if (res) {
       dir.create(dir_file)

--- a/R/graph_create.R
+++ b/R/graph_create.R
@@ -267,8 +267,9 @@ graph_create <- function(tag,
 
       # The minimal distance between grid cell is not from the center of the cell, but from one edge
       # to the other (opposite) edge. So the minimal distance between cell should be reduce by the
-      # grid resolution.
-      dist <- pmax(dist - resolution[s_id[, 1]], 0)
+      # grid resolution. We still want to keep the distance 0 only to the actual same pixel, so we
+      # make the distance at a minimum of 1 if initial distance is greater than 1.
+      dist[dist > 0] <- pmax(dist[dist > 0] - resolution[s_id[, 1]], 1)
 
       # Compute groundspeed
       gs_abs <- dist / flight_duration[i_s]

--- a/R/graph_transition.R
+++ b/R/graph_transition.R
@@ -30,7 +30,10 @@ graph_transition <- function(graph) {
 
 
   if (graph$param$graph_set_movement$type == "as") {
-    transition <- speed2prob(graph$gs - graph$ws, graph$param$graph_set_movement)
+    as <- graph$gs - graph$ws
+    # Set airspeed to zero when distance is zero (groundspeed=0)
+    as[graph$gs == 0] <- 0
+    transition <- speed2prob(as, graph$param$graph_set_movement)
   } else if (graph$param$graph_set_movement$type == "gs") {
     transition <- speed2prob(graph$gs, graph$param$graph_set_movement)
   } else {

--- a/R/param_create.R
+++ b/R/param_create.R
@@ -85,7 +85,7 @@ param_create <- function(id, default = FALSE, ...) {
         low_speed_fix = formals(graph_set_movement)$low_speed_fix,
         zero_speed_ratio = formals(graph_set_movement)$zero_speed_ratio
       ),
-      bird = list(
+      bird_create = list(
         mass = formals(bird_create)$mass,
         wing_span = formals(bird_create)$wing_span,
         wing_aspect = formals(bird_create)$wing_aspect,

--- a/R/param_create.R
+++ b/R/param_create.R
@@ -85,7 +85,7 @@ param_create <- function(id, default = FALSE, ...) {
         low_speed_fix = formals(graph_set_movement)$low_speed_fix,
         zero_speed_ratio = formals(graph_set_movement)$zero_speed_ratio
       ),
-      bird_create = list(
+      bird = list(
         mass = formals(bird_create)$mass,
         wing_span = formals(bird_create)$wing_span,
         wing_aspect = formals(bird_create)$wing_aspect,

--- a/R/param_create.R
+++ b/R/param_create.R
@@ -151,7 +151,7 @@ merge_params <- function(base_param, overlay_param, only_in_base = FALSE) {
       if (!only_in_base || (name %in% base_param)) {
         base <- base_param[[name]]
         overlay <- overlay_param[[name]]
-        if (!is.null(base) && is.list(base) && is.list(overlay)) {
+        if (!is.null(base) && is.list(base)) {
           merged_param[[name]] <- merge_params(base, overlay)
         } else {
           merged_param[[name]] <- NULL

--- a/R/param_create.R
+++ b/R/param_create.R
@@ -82,7 +82,8 @@ param_create <- function(id, default = FALSE, ...) {
         scale = formals(graph_set_movement)$scale,
         location = formals(graph_set_movement)$location,
         power2prob = formals(graph_set_movement)$power2prob,
-        low_speed_fix = formals(graph_set_movement)$low_speed_fix
+        low_speed_fix = formals(graph_set_movement)$low_speed_fix,
+        zero_speed_ratio = formals(graph_set_movement)$zero_speed_ratio
       ),
       bird = list(
         mass = formals(bird_create)$mass,

--- a/R/plot.map.R
+++ b/R/plot.map.R
@@ -59,8 +59,8 @@
 #' @method plot map
 #' @export
 plot.map <- function(x,
-                     thr_likelihood = 1,
                      path = NULL,
+                     thr_likelihood = 1,
                      plot_leaflet = TRUE,
                      provider = "Esri.WorldTopoMap",
                      provider_options = leaflet::providerTileOptions(),
@@ -178,14 +178,15 @@ plot.map <- function(x,
     if (!is.null(path)) {
       lmap <- plot_path_leaflet(lmap, path)
 
-      for (i in seq_len(nrow(path))) {
-        if (!is.na(path$lon[i])) {
+      for (i in seq_len(max(path$stap_id))) {
+        path_stap_id <- path[path$stap_id == i, ]
+        if (any(!is.na(path_stap_id$lon[i]))) {
           lmap <- leaflet::addCircleMarkers(
             lmap,
-            lng = path$lon[i],
-            lat = path$lat[i],
+            lng = path_stap_id$lon,
+            lat = path_stap_id$lat,
             group = grp[i],
-            radius = stap2duration(path[i, ])^(0.25) * 6,
+            radius = stap2duration(path_stap_id)^(0.25) * 6,
             stroke = TRUE,
             color = "white",
             weight = 2,
@@ -193,7 +194,9 @@ plot.map <- function(x,
             fill = TRUE,
             fillColor = "black",
             fillOpacity = 1,
-            label = glue::glue("#{path$stap_id[i]}, {round(stap2duration(path)[i], 1)} days")
+            label = glue::glue(
+              "#{path_stap_id$stap_id[1]}, {round(stap2duration(path_stap_id)[1], 1)} days"
+            )
           )
         }
       }

--- a/R/plot.tag.R
+++ b/R/plot.tag.R
@@ -196,10 +196,14 @@ plot_tag_pressure <- function(tag,
       value = abs(diff(pres$value)),
       value_avg = utils::head(pres$value, -1) + diff(pres$value) / 2,
       date = utils::head(pres$date, -1) + diff(pres$date) / 2,
+      date_diff = as.numeric(diff(pres$date), units = "hours"),
+      same_stapelev = utils::head(pres$stapelev, -1) == utils::tail(pres$stapelev, -1),
       stap_id = (utils::tail(pres$stap_id, -1) + utils::head(pres$stap_id, -1)) / 2
     )
     # Only keep the 1 hours difference
-    pres_diff <- pres_diff[as.numeric(diff(pres$date), units = "hours") == 1, ]
+    pres_diff <- pres_diff[pres_diff$date_diff == 1, ]
+    # Only keep if belonging to the the same stapelev
+    pres_diff <- pres_diff[pres_diff$same_stapelev, ]
     # Remove diff overlapping between stationary periods/flight
     pres_diff <- pres_diff[(pres_diff$stap_id %% 1) == 0 & pres_diff$stap_id != 0, ]
     # Only keep difference which are above warning limit

--- a/R/plot_graph_movement.R
+++ b/R/plot_graph_movement.R
@@ -11,7 +11,7 @@
 #' @family movement
 #' @export
 plot_graph_movement <- function(graph,
-                                speed = seq(1, 120),
+                                speed = seq(0, 120),
                                 plot_plotly = FALSE) {
   # Check that graph is correct
   graph_assert(graph, "movement")

--- a/R/plot_path.R
+++ b/R/plot_path.R
@@ -149,33 +149,41 @@ plot_path_leaflet <- function(
   # Remove position of stap not included/not available
   path_full <- path[!is.na(path$lat), ]
 
+  # Get number of path
+  unique_j <- unique(path$j)
+
   # Plot trajectory of all available point in grey
   if (nrow(path_full) < nrow(path)) {
     polyline_full <- polyline
     # polyline_full$weight <- polyline_full$weight/2
     polyline_full$opacity <- polyline_full$opacity / 2
     polyline_full$color <- "grey"
-    map <- do.call(leaflet::addPolylines, c(
-      list(
-        map = map,
-        lng = path_full$lon,
-        lat = path_full$lat,
-        group = path_full$j
-      ),
-      polyline_full
-    ))
+
+    for (j in unique_j) {
+      map <- do.call(leaflet::addPolylines, c(
+        list(
+          map = map,
+          lng = path_full$lon[path_full$j == j],
+          lat = path_full$lat[path_full$j == j],
+          group = path$j[path$j == j]
+        ),
+        polyline_full
+      ))
+    }
   }
 
   # Overlay with trajectory of consecutive position in black.
-  map <- do.call(leaflet::addPolylines, c(
-    list(
-      map = map,
-      lng = path$lon,
-      lat = path$lat,
-      group = path$j
-    ),
-    polyline
-  ))
+  for (j in unique_j) {
+    map <- do.call(leaflet::addPolylines, c(
+      list(
+        map = map,
+        lng = path$lon[path$j == j],
+        lat = path$lat[path$j == j],
+        group = path$j[path$j == j]
+      ),
+      polyline
+    ))
+  }
 
   suppressWarnings({
     map <- do.call(leaflet::addCircleMarkers, c(

--- a/R/print.bird.R
+++ b/R/print.bird.R
@@ -18,11 +18,11 @@ print.bird <- function(x, ...) {
   bird <- x
   cli::cli_h1("GeoPressureR `bird` object")
   cli::cli_bullets(c(
-    "*" = "Scientific name: {bird$scientific_name}",
-    "*" = "Mass: {round(bird$mass,2)} (kg).",
-    "*" = "Body frontal area: {round(bird$body_frontal_area,1)} (m^2).",
-    "*" = "Wing span: {round(bird$wing_span,1)} (m).",
-    "*" = "Wing aspect: {round(bird$wing_aspect,1)} (-)."
+    "*" = "Scientific name: {bird_create$scientific_name}",
+    "*" = "Mass: {round(bird_create$mass,2)} (kg).",
+    "*" = "Body frontal area: {round(bird_create$body_frontal_area,1)} (m^2).",
+    "*" = "Wing span: {round(bird_create$wing_span,1)} (m).",
+    "*" = "Wing aspect: {round(bird_create$wing_aspect,1)} (-)."
   ))
   return(invisible(bird))
 }

--- a/R/print.bird.R
+++ b/R/print.bird.R
@@ -18,11 +18,11 @@ print.bird <- function(x, ...) {
   bird <- x
   cli::cli_h1("GeoPressureR `bird` object")
   cli::cli_bullets(c(
-    "*" = "Scientific name: {bird_create$scientific_name}",
-    "*" = "Mass: {round(bird_create$mass,2)} (kg).",
-    "*" = "Body frontal area: {round(bird_create$body_frontal_area,1)} (m^2).",
-    "*" = "Wing span: {round(bird_create$wing_span,1)} (m).",
-    "*" = "Wing aspect: {round(bird_create$wing_aspect,1)} (-)."
+    "*" = "Scientific name: {bird$scientific_name}",
+    "*" = "Mass: {round(bird$mass,2)} (kg).",
+    "*" = "Body frontal area: {round(bird$body_frontal_area,1)} (m^2).",
+    "*" = "Wing span: {round(bird$wing_span,1)} (m).",
+    "*" = "Wing aspect: {round(bird$wing_aspect,1)} (-)."
   ))
   return(invisible(bird))
 }

--- a/R/print.param.R
+++ b/R/print.param.R
@@ -82,6 +82,7 @@ print.param <- function(x, ...) {
   bullets(param, "bird")
   bullets(param$graph_set_movement, "power2prob")
   bullets(param$graph_set_movement, "low_speed_fix")
+  bullets(param$graph_set_movement, "zero_speed_ratio")
 
   cli::cli_h3("Outputs {.fun graph_simulation} {.fun pressurepath_create}")
   bullets(param$graph_simulation, "nj")

--- a/R/print.param.R
+++ b/R/print.param.R
@@ -79,7 +79,7 @@ print.param <- function(x, ...) {
   bullets(param$graph_set_movement, "shape")
   bullets(param$graph_set_movement, "scale")
   bullets(param$graph_set_movement, "location")
-  bullets(param, "bird")
+  bullets(param, "bird_create")
   bullets(param$graph_set_movement, "power2prob")
   bullets(param$graph_set_movement, "low_speed_fix")
   bullets(param$graph_set_movement, "zero_speed_ratio")

--- a/R/speed2prob.R
+++ b/R/speed2prob.R
@@ -122,16 +122,16 @@ speed2power <- function(as, bird) {
 
   # Induce power (eq 16 of Box 3.1) Pind is due to the active acceleration of mass flow in order to
   # produce a force opposing weight and drag
-  p_ind <- 2 * k * (bird$mass * g)^2 / (as * pi * bird$wing_span^2 * rho)
+  p_ind <- 2 * k * (bird_create$mass * g)^2 / (as * pi * bird_create$wing_span^2 * rho)
 
   # Parasitic power (eq 3 of Box 3.2) (also called Body Power) due to drag on the body
-  p_par <- rho * as^3 * bird$body_frontal_area * c_db / 2
+  p_par <- rho * as^3 * bird_create$body_frontal_area * c_db / 2
 
   # Profile power due to the local drag on the wings
-  p_am <- 1.05 * k^(3 / 4) * bird$mass^(3 / 2) * g^(3 / 2) *
-    bird$body_frontal_area^(1 / 4) * c_db^(1 / 4) / rho^(1 / 2) /
-    bird$wing_span^(3 / 2)
-  p_pro <- c_pro / bird$wing_aspect * p_am
+  p_am <- 1.05 * k^(3 / 4) * bird_create$mass^(3 / 2) * g^(3 / 2) *
+    bird_create$body_frontal_area^(1 / 4) * c_db^(1 / 4) / rho^(1 / 2) /
+    bird_create$wing_span^(3 / 2)
+  p_pro <- c_pro / bird_create$wing_aspect * p_am
 
   # Total Mechanical Power (eq 1 of Box 3.4)
   p_mech <- p_ind + p_par + p_pro

--- a/R/speed2prob.R
+++ b/R/speed2prob.R
@@ -51,6 +51,7 @@ speed2prob <- function(speed, movement) {
   # The normalization is computed as the sum of probability with a 1km/h unit grid
   norm_speed <- pmax(seq(0, 150), movement$low_speed_fix)
 
+  speed_0 <- speed == 0
   speed <- pmax(speed, movement$low_speed_fix)
 
   if (movement$method == "gamma") {
@@ -75,6 +76,8 @@ speed2prob <- function(speed, movement) {
 
     prob <- movement$power2prob(speed2power(as, movement$bird)) / norm
   }
+
+  prob[speed_0] <- prob[speed_0] * movement$zero_speed_ratio
 
   return(prob)
 }

--- a/R/speed2prob.R
+++ b/R/speed2prob.R
@@ -122,16 +122,16 @@ speed2power <- function(as, bird) {
 
   # Induce power (eq 16 of Box 3.1) Pind is due to the active acceleration of mass flow in order to
   # produce a force opposing weight and drag
-  p_ind <- 2 * k * (bird_create$mass * g)^2 / (as * pi * bird_create$wing_span^2 * rho)
+  p_ind <- 2 * k * (bird$mass * g)^2 / (as * pi * bird$wing_span^2 * rho)
 
   # Parasitic power (eq 3 of Box 3.2) (also called Body Power) due to drag on the body
-  p_par <- rho * as^3 * bird_create$body_frontal_area * c_db / 2
+  p_par <- rho * as^3 * bird$body_frontal_area * c_db / 2
 
   # Profile power due to the local drag on the wings
-  p_am <- 1.05 * k^(3 / 4) * bird_create$mass^(3 / 2) * g^(3 / 2) *
-    bird_create$body_frontal_area^(1 / 4) * c_db^(1 / 4) / rho^(1 / 2) /
-    bird_create$wing_span^(3 / 2)
-  p_pro <- c_pro / bird_create$wing_aspect * p_am
+  p_am <- 1.05 * k^(3 / 4) * bird$mass^(3 / 2) * g^(3 / 2) *
+    bird$body_frontal_area^(1 / 4) * c_db^(1 / 4) / rho^(1 / 2) /
+    bird$wing_span^(3 / 2)
+  p_pro <- c_pro / bird$wing_aspect * p_am
 
   # Total Mechanical Power (eq 1 of Box 3.4)
   p_mech <- p_ind + p_par + p_pro

--- a/R/tag_assert.R
+++ b/R/tag_assert.R
@@ -94,7 +94,7 @@ tag_assert <- function(tag, condition = "tag", type = "abort") {
   }
 
   if (type == "inform") {
-    cli::cli_inform(msg)
+    cli::cli_bullets(msg)
   } else if (type == "warn") {
     cli::cli_warn(msg)
   } else {

--- a/R/tag_create.R
+++ b/R/tag_create.R
@@ -486,6 +486,8 @@ tag_create_migratetech <- function(tag,
                contains {.val Type:x}, with x>=13."
     )
   }
+  # Retrieve full model number
+  tag$param$migratec_model <- regmatches(line2, regexpr("Type: \\K[\\d.]+", line2, perl = TRUE))
   line16 <- readLines(deg_path, n = 16)[[16]]
   drift <- abs(as.numeric(regmatches(line16, regexpr("-?\\d+\\.\\d*", line16))) / 60)
   if (drift > 30) {

--- a/R/tag_create.R
+++ b/R/tag_create.R
@@ -444,10 +444,12 @@ tag_create_soi <- function(tag,
   tryCatch(
     {
       setting_path <- tag_create_detect("*.settings", directory, quiet = TRUE)
-      tag$param$soi_settings <- jsonlite::fromJSON(setting_path)
+      if (!is.null(setting_path)) {
+        tag$param$soi_settings <- jsonlite::fromJSON(setting_path)
+      }
     },
     error = function(e) {
-      cli::cli_alert_warning("Failed to load {.file {setting_path}}.")
+      cli::cli_alert_warning("Failed to load the SOI setting file {.file {setting_path}}.")
       message(e$message)
     }
   )

--- a/R/tag_create.R
+++ b/R/tag_create.R
@@ -443,7 +443,7 @@ tag_create_soi <- function(tag,
 
   tryCatch(
     {
-      setting_path <- GeoPressureR:::tag_create_detect("*.settings", directory, quiet = TRUE)
+      setting_path <- tag_create_detect("*.settings", directory, quiet = TRUE)
       tag$param$soi_settings <- jsonlite::fromJSON(setting_path)
     },
     error = function(e) {

--- a/R/tag_create.R
+++ b/R/tag_create.R
@@ -824,10 +824,9 @@ tag_create_csv <- function(sensor_path, col_name, quiet = FALSE) {
                               {glue::glue_collapse(missing_cols, ', ')}"))
   }
 
-  df$datetime <- as.POSIXct(
-    ifelse(grepl(" ", df$datetime), df$datetime, paste0(df$datetime, " 00:00:00")),
-    format = "%Y-%m-%d %H:%M:%S", tz = "UTC"
-  )
+  # Rename column datetime to date and convert to posixct
+  names(df)[names(df) == "datetime"] <- "date"
+  df$date <- as.POSIXct(strptime(df$date, format = "%Y-%m-%dT%H:%M:%OS", tz = "UTC"))
 
   if (!quiet) {
     cli::cli_inform(c("v" = "Read {.file {sensor_path}}"))

--- a/R/tag_create.R
+++ b/R/tag_create.R
@@ -441,10 +441,16 @@ tag_create_soi <- function(tag,
   tag$param$tag_create$temperature_internal_file <- temperature_internal_path
   tag$param$tag_create$magnetic_file <- magnetic_path
 
-  setting_path <- tag_create_detect("*.settings", directory, quiet = TRUE)
-  if (!is.null(setting_path)) {
-    tag$param$soi_settings <- jsonlite::fromJSON(setting_path)
-  }
+  tryCatch(
+    {
+      setting_path <- GeoPressureR:::tag_create_detect("*.settings", directory, quiet = TRUE)
+      tag$param$soi_settings <- jsonlite::fromJSON(setting_path)
+    },
+    error = function(e) {
+      cli::cli_alert_warning("Failed to load {.file {setting_path}}.")
+      message(e$message)
+    }
+  )
 
   return(tag)
 }

--- a/R/tag_create.R
+++ b/R/tag_create.R
@@ -608,7 +608,7 @@ tag_create_lund <- function(tag,
     value = xls$`Pressure [hPa]`
   )
   if (!quiet) {
-    cli::cli_inform(c("v" = "Read {.file {pressure_path}}"))
+    cli::cli_bullets(c("v" = "Read {.file {pressure_path}}"))
   }
 
 
@@ -636,7 +636,7 @@ tag_create_lund <- function(tag,
     )
 
     if (!quiet) {
-      cli::cli_inform(c("v" = "Read {.file {acc_light_path}}"))
+      cli::cli_bullets(c("v" = "Read {.file {acc_light_path}}"))
     }
   }
 
@@ -807,7 +807,7 @@ tag_create_dto <- function(sensor_path,
   }
 
   if (!quiet) {
-    cli::cli_inform(c("v" = "Read {.file {sensor_path}}"))
+    cli::cli_bullets(c("v" = "Read {.file {sensor_path}}"))
   }
   return(df)
 }
@@ -829,7 +829,7 @@ tag_create_csv <- function(sensor_path, col_name, quiet = FALSE) {
   df$date <- as.POSIXct(strptime(df$date, format = "%Y-%m-%dT%H:%M:%OS", tz = "UTC"))
 
   if (!quiet) {
-    cli::cli_inform(c("v" = "Read {.file {sensor_path}}"))
+    cli::cli_bullets(c("v" = "Read {.file {sensor_path}}"))
   }
 
   return(df)

--- a/R/tag_download_wind.R
+++ b/R/tag_download_wind.R
@@ -40,6 +40,9 @@
 #' @param file absolute or relative path of the ERA5 wind data file to be downloaded. Function
 #' taking as single argument the stationary period identifier.
 #' @param overwrite logical. If `TRUE`, file is overwritten.
+#' @inheritParams ecmwfr::wf_request_batch
+#' @inheritDotParams ecmwfr::wf_request_batch
+#'
 #' @return the path of the downloaded (requested file) or the an R6 object with download/transfer
 #' information
 #'
@@ -56,7 +59,9 @@ tag_download_wind <- function(
     variable = c("u_component_of_wind", "v_component_of_wind"),
     cds_token = Sys.getenv("cds_token"),
     file = \(stap_id) glue::glue("./data/wind/{tag$param$id}/{tag$param$id}_{stap_id}.nc"),
-    overwrite = FALSE) {
+    overwrite = FALSE,
+    workers = 19,
+    ...) {
   tag_assert(tag, "setmap")
 
   stap <- tag$stap
@@ -160,10 +165,8 @@ tag_download_wind <- function(
 
   ecmwfr::wf_request_batch(
     request_list[include_stap_id],
-    workers = 20,
-    # user = ,
+    workers = workers,
     path = directory,
-    # time_out = 3600,
-    # total_timeout = length(request_list) * time_out/workers
+    ...
   )
 }

--- a/R/tag_label.R
+++ b/R/tag_label.R
@@ -68,7 +68,7 @@ tag_label <- function(tag,
 
     # Suggest to write the file
     file_default <- glue::glue("./data/tag-label/{tag$param$id}.csv")
-    cli::cli_inform(c("!" = "The label file {.file {file}} does not exist."))
+    cli::cli_bullets(c("!" = "The label file {.file {file}} does not exist."))
     choices <- list(
       "1" = "No",
       "2" = glue::glue("Yes, in `{file_default}` (default)"),
@@ -90,7 +90,7 @@ tag_label <- function(tag,
   } else {
     # Check if label has already been setmap
     if ("setmap" %in% tag_status(tag)) {
-      cli::cli_inform(c("!" = "The setmap has already been defined for {.var tag}."))
+      cli::cli_bullets(c("!" = "The setmap has already been defined for {.var tag}."))
       choices <- list(
         "1" = glue::glue("No, return the original `tag`"),
         "2" = glue::glue("Yes, read the new label, but start `tag` from scratch"),

--- a/R/tag_label_write.R
+++ b/R/tag_label_write.R
@@ -41,9 +41,9 @@ tag_label_write <- function(tag,
   if (!assertthat::has_name(tag$pressure, "label")) {
     tag <- tag_label_auto(tag)
     if (!quiet) {
-      cli::cli_inform(c(
+      cli::cli_bullets(c(
         "i" = "No label data.",
-        ">" = "Initialize automatically label using {.fn tag_label_auto}\f"
+        ">" = "Initialize automatically label using {.fn tag_label_auto}"
       ))
     }
   }
@@ -59,9 +59,9 @@ tag_label_write <- function(tag,
   if (assertthat::has_name(tag, "acceleration")) {
     if (!assertthat::has_name(tag$acceleration, "label")) {
       tag <- tag_label_auto(tag)
-      cli::cli_inform(c(
+      cli::cli_bullets(c(
         "i" = "No acceleration label data.",
-        ">" = "Initialize acceleration label with default {.fn tag_label_auto}\f"
+        ">" = "Initialize acceleration label with default {.fn tag_label_auto}"
       ))
     }
     tag$acceleration$series <- "acceleration"

--- a/R/tag_set_map.R
+++ b/R/tag_set_map.R
@@ -102,7 +102,8 @@ tag_set_map <- function(tag,
   # Only use the required column. Other names can cause issue later...
   unexpected_cols <- setdiff(names(known), c("stap_id", "known_lat", "known_lon"))
   if (length(unexpected_cols)) {
-    cli_warn("Unexpected columns found in {.var known}: {paste(unexpected_cols, collapse = ', ')}")
+    cli::cli_warn("Unexpected columns found in {.var known}: \\
+                  {paste(unexpected_cols, collapse = ', ')}")
     known <- known[, c("stap_id", "known_lat", "known_lon")]
   }
   known <- known[, c("stap_id", "known_lat", "known_lon")]

--- a/R/tag_set_map.R
+++ b/R/tag_set_map.R
@@ -141,7 +141,7 @@ tag_set_map <- function(tag,
     if (chg_known || chg_extent || chg_scale || chg_include) {
       # Only provide option to stop the process if map are already defined
       if (any(c("map_pressure", "map_light") %in% names(tag))) {
-        cli::cli_inform(c("!" = "The likelihood map ({.var map_pressure} and/or {.var map_light}) \\
+        cli::cli_bullets(c("!" = "The likelihood map ({.var map_pressure} and/or {.var map_light}) \\
           have already been computed on this {.var tag} object with different setmap parameters."))
         res <- utils::askYesNo(
           "Do you want to overwrite the parameters and delete the likelihood maps?"

--- a/R/tag_set_map.R
+++ b/R/tag_set_map.R
@@ -99,6 +99,13 @@ tag_set_map <- function(tag,
   assertthat::assert_that(assertthat::has_name(known, "stap_id"))
   assertthat::assert_that(assertthat::has_name(known, "known_lat"))
   assertthat::assert_that(assertthat::has_name(known, "known_lon"))
+  # Only use the required column. Other names can cause issue later...
+  unexpected_cols <- setdiff(names(known), c("stap_id", "known_lat", "known_lon"))
+  if (length(unexpected_cols)) {
+    cli_warn("Unexpected columns found in {.var known}: {paste(unexpected_cols, collapse = ', ')}")
+    known <- known[, c("stap_id", "known_lat", "known_lon")]
+  }
+  known <- known[, c("stap_id", "known_lat", "known_lon")]
   if (!all(known$known_lon >= extent[1] & known$known_lon <= extent[2] &
     known$known_lat >= extent[3] & known$known_lat <= extent[4])) {
     cli::cli_abort(c(

--- a/R/tag_set_map.R
+++ b/R/tag_set_map.R
@@ -106,6 +106,9 @@ tag_set_map <- function(tag,
       i = "Modify {.var extent} or {.var known} to match this requirement."
     ))
   }
+  if (anyDuplicated(known$stap_id)) {
+    cli::cli_abort("{.var known} contains duplicate {.field stap_id} values.")
+  }
   # Keep a copy of the original known to keep in param. Useful to keep negative indexing
   known0 <- known
   # Use negative indexing: e.g. replace known$stap_id = -1 to the last stap
@@ -141,8 +144,10 @@ tag_set_map <- function(tag,
     if (chg_known || chg_extent || chg_scale || chg_include) {
       # Only provide option to stop the process if map are already defined
       if (any(c("map_pressure", "map_light") %in% names(tag))) {
-        cli::cli_bullets(c("!" = "The likelihood map ({.var map_pressure} and/or {.var map_light}) \\
-          have already been computed on this {.var tag} object with different setmap parameters."))
+        cli::cli_bullets(
+          c("!" = "The likelihood map ({.var map_pressure} and/or {.var map_light}) \\
+          have already been computed on this {.var tag} object with different setmap parameters.")
+        )
         res <- utils::askYesNo(
           "Do you want to overwrite the parameters and delete the likelihood maps?"
         )

--- a/R/tag_set_map.R
+++ b/R/tag_set_map.R
@@ -86,6 +86,9 @@ tag_set_map <- function(tag,
   assertthat::assert_that(all(stap$stap_id == seq_len(nrow(stap))))
 
   # Check extent and scale
+  if (is.list(extent)) {
+    extent <- unlist(extent)
+  }
   map_expand(extent, scale)
 
   # Check known

--- a/R/trainset_write.R
+++ b/R/trainset_write.R
@@ -47,7 +47,7 @@ trainset_write <- function(df,
   # Check if folder exist
   dir_file <- dirname(file)
   if (!dir.exists(dir_file)) {
-    cli::cli_inform(c("!" = "The directory {.file {dir_file}} does not exists."))
+    cli::cli_bullets(c("!" = "The directory {.file {dir_file}} does not exists."))
     res <- utils::askYesNo("Do you want to create it?")
     if (res) {
       dir.create(dir_file)
@@ -64,7 +64,7 @@ trainset_write <- function(df,
   )
 
   if (!quiet) {
-    cli::cli_inform(c("v" = "{.file {file}} written successfully."))
+    cli::cli_bullets(c("v" = "{.file {file}} written successfully."))
   }
   return(file)
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -17,7 +17,7 @@ knitr::opts_chunk$set(
 
 <!-- badges: start -->
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7754457.svg)](https://doi.org/10.5281/zenodo.7754457)
-[![R-CMD-check](https://github.com/Rafnuss/GeoPressureR/workflows/R-CMD-check/badge.svg)](https://github.com/Rafnuss/GeoPressureR/actions/workflows/R-CMD-check.yaml)
+[![R-CMD-check](https://github.com/Rafnuss/GeoPressureR/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/Rafnuss/GeoPressureR/actions/workflows/R-CMD-check.yaml)
 [![pkgdown](https://github.com/Rafnuss/GeoPressureR/actions/workflows/pkgdown.yaml/badge.svg)](https://github.com/Rafnuss/GeoPressureR/actions/workflows/pkgdown.yaml)
 [![Codecov test coverage](https://codecov.io/gh/Rafnuss/GeoPressureR/branch/master/graph/badge.svg)](https://app.codecov.io/gh/Rafnuss/GeoPressureR?branch=master)
 [![lint](https://github.com/Rafnuss/GeoPressureR/actions/workflows/lint.yaml/badge.svg)](https://github.com/Rafnuss/GeoPressureR/actions/workflows/lint.yaml)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <!-- badges: start -->
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7754457.svg)](https://doi.org/10.5281/zenodo.7754457)
-[![R-CMD-check](https://github.com/Rafnuss/GeoPressureR/workflows/R-CMD-check/badge.svg)](https://github.com/Rafnuss/GeoPressureR/actions)
+[![R-CMD-check](https://github.com/Rafnuss/GeoPressureR/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/Rafnuss/GeoPressureR/actions/workflows/R-CMD-check.yaml)
 [![pkgdown](https://github.com/Rafnuss/GeoPressureR/actions/workflows/pkgdown.yaml/badge.svg)](https://github.com/Rafnuss/GeoPressureR/actions/workflows/pkgdown.yaml)
 [![Codecov test
 coverage](https://codecov.io/gh/Rafnuss/GeoPressureR/branch/master/graph/badge.svg)](https://app.codecov.io/gh/Rafnuss/GeoPressureR?branch=master)

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,4 +1,4 @@
-citHeader("To cite GeoPressureR in publications use the following (nussbaumer2022 for the R code and nussbaumer2023a, nussbaumer2023b for the method:)
+citHeader("To cite GeoPressureR in publications use the following (nussbaumer2022 for the R code and nussbaumer2023a, nussbaumer2023b for the method:")
 
 citEntry(
   entry   = "manual",

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,11 +1,11 @@
-citHeader("To cite GeoPressureR in publications use the following (nussbaumer2022 for the R code, nussbaumer2024 for the analysis instruction (e.g. labeling explanation),  and nussbaumer2023a, nussbaumer2023b for the method:")
+citHeader("To cite GeoPressureR in publications use the following (nussbaumer2022 for the R code, nussbaumer2024 for the explanation of implementation,  and nussbaumer2023a, nussbaumer2023b for the method:")
 
 citEntry(
   entry   = "manual",
   textVersion = "nussbaumer2022",
   title   = "GeoPressureR: Global positioning by atmospheric pressure",
   author  = personList(
-  person("Raphael", "Nussbaumer", email = "rafnuss@gmail.com", comment = c(ORCID = "0000-0002-8185-1020")),
+    person("Raphael", "Nussbaumer", email = "rafnuss@gmail.com", comment = c(ORCID = "0000-0002-8185-1020")),
     person("Mathieu", "Gravey", email = "mathieu@mgravey.com", comment = c(ORCID = "0000-0002-0871-1507"))
   ),
   doi     = "10.5281/zenodo.7754457",
@@ -18,7 +18,8 @@ citEntry(
   textVersion = "nussbaumer2023a",
   title   = "Global positioning with animal-borne pressure sensors",
   author  = personList(
-  person("Raphael", "Nussbaumer", email = "rafnuss@gmail.com", comment = c(ORCID = "0000-0002-8185-1020")),
+  person(
+    "Raphael", "Nussbaumer", email = "rafnuss@gmail.com", comment = c(ORCID = "0000-0002-8185-1020")),
     person("Mathieu", "Gravey", email = "mathieu@mgravey.com", comment = c(ORCID = "0000-0002-0871-1507")),
     person("Martins", "Briedis", email = "martins.briedis@vogelwarte.ch ", comment = c(ORCID = "0000-0002-9434-9056")),
     person("Felix", "Liechti", email = "felix.liechti@vogelwarte.ch", comment = c(ORCID = "0000-0001-9473-0837"))
@@ -37,7 +38,8 @@ citEntry(
   textVersion = "nussbaumer2023b",
   title   = "Reconstructing bird trajectories from pressure and wind data using a highly optimised hidden Markov model",
   author  = personList(
-  person("Raphael", "Nussbaumer", email = "rafnuss@gmail.com", comment = c(ORCID = "0000-0002-8185-1020")),
+  person(
+    "Raphael", "Nussbaumer", email = "rafnuss@gmail.com", comment = c(ORCID = "0000-0002-8185-1020")),
     person("Mathieu", "Gravey", email = "mathieu@mgravey.com", comment = c(ORCID = "0000-0002-0871-1507")),
     person("Martins", "Briedis", email = "martins.briedis@vogelwarte.ch ", comment = c(ORCID = "0000-0002-9434-9056")),
     person("Felix", "Liechti", email = "felix.liechti@vogelwarte.ch", comment = c(ORCID = "0000-0001-9473-0837")),

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,4 +1,4 @@
-citHeader("To cite GeoPressureR in publications use the following (nussbaumer2022 for the R code and nussbaumer2023a, nussbaumer2023b for the method:")
+citHeader("To cite GeoPressureR in publications use the following (nussbaumer2022 for the R code, nussbaumer2024 for the analysis instruction (e.g. labeling explanation),  and nussbaumer2023a, nussbaumer2023b for the method:")
 
 citEntry(
   entry   = "manual",
@@ -8,6 +8,7 @@ citEntry(
   person("Raphael", "Nussbaumer", email = "rafnuss@gmail.com", comment = c(ORCID = "0000-0002-8185-1020")),
     person("Mathieu", "Gravey", email = "mathieu@mgravey.com", comment = c(ORCID = "0000-0002-0871-1507"))
   ),
+  doi     = "10.5281/zenodo.7754457",
   url     = "https://github.com/Rafnuss/GeoPressureR",
   year    = "2022"
 )
@@ -50,6 +51,19 @@ citEntry(
   volume  = "14",
   number  = "4",
   pages   = "1108-1129",
+)
+
+citEntry(
+  entry   = "manual",
+  textVersion = "nussbaumer2024",
+  title   = "GeoPressureManual: Learn how to use GeoPressureR with examples.",
+  author  = personList(
+  person("Raphael", "Nussbaumer", email = "rafnuss@gmail.com", comment = c(ORCID = "0000-0002-8185-1020")),
+    person("Améline", "Nussbaumer", email = "ameline.nussbaumer@gmail.com", comment = c(ORCID = "0000-0003-1308-4154"))
+  ),
+  doi     = "10.5281/zenodo.10799355",
+  url     = "https://github.com/Rafnuss/GeoPressureManual",
+  year    = "2024"
 )
 
 

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,4 +1,16 @@
-citHeader("To cite GeoPressureR in publications use the following (nussbaumer2023a and nussbaumer2023b for the method and nussbaumer2022 for the R code")
+citHeader("To cite GeoPressureR in publications use the following (nussbaumer2022 for the R code and nussbaumer2023a, nussbaumer2023b for the method:)
+
+citEntry(
+  entry   = "manual",
+  textVersion = "nussbaumer2022",
+  title   = "GeoPressureR: Global positioning by atmospheric pressure",
+  author  = personList(
+  person("Raphael", "Nussbaumer", email = "rafnuss@gmail.com", comment = c(ORCID = "0000-0002-8185-1020")),
+    person("Mathieu", "Gravey", email = "mathieu@mgravey.com", comment = c(ORCID = "0000-0002-0871-1507"))
+  ),
+  url     = "https://github.com/Rafnuss/GeoPressureR",
+  year    = "2022"
+)
 
 citEntry(
   entry   = "Article",
@@ -41,14 +53,4 @@ citEntry(
 )
 
 
-citEntry(
-  entry   = "manual",
-  textVersion = "nussbaumer2022",
-  title   = "GeoPressureR: Global positioning by atmospheric pressure",
-  author  = personList(
-  person("Raphael", "Nussbaumer", email = "rafnuss@gmail.com", comment = c(ORCID = "0000-0002-8185-1020")),
-    person("Mathieu", "Gravey", email = "mathieu@mgravey.com", comment = c(ORCID = "0000-0002-0871-1507"))
-  ),
-  url     = "https://github.com/Rafnuss/GeoPressureR",
-  year    = "2022"
-)
+

--- a/man/graph_create.Rd
+++ b/man/graph_create.Rd
@@ -62,7 +62,7 @@ representing the E-W as real and S-N as imaginary
 This function returns a trellis graph representing the trajectory of a bird based on filtering
 and pruning the likelihood maps provided.
 
-In the final graph, we only keep the most likely nodes (i.e., position of the bird at each
+In the final graph, we only keep the likely nodes (i.e., position of the bird at each
 stationary periods) defined as (1) those whose likelihood value are within the threshold of
 percentile \code{thr_likelihood} of the total likelihood map and (2) those which are connected to
 at least one edge of the previous and next stationary periods requiring an average ground speed

--- a/man/graph_set_movement.Rd
+++ b/man/graph_set_movement.Rd
@@ -13,7 +13,8 @@ graph_set_movement(
   location = 40,
   bird = NULL,
   power2prob = function(power) (1/power)^3,
-  low_speed_fix = 15
+  low_speed_fix = 15,
+  zero_speed_ratio = 1
 )
 }
 \arguments{
@@ -23,19 +24,25 @@ graph_set_movement(
 
 \item{method}{method used to convert the speed to probability ("gamma", "logis" or "power")}
 
-\item{shape}{parameter of the gamma distribution}
+\item{shape}{parameter of the gamma distribution (km/h)}
 
-\item{scale}{parameter of the gamma and logistic distribution}
+\item{scale}{parameter of the gamma and logistic distribution (km/h)}
 
-\item{location}{parameter for the logistic distribution}
+\item{location}{parameter for the logistic distribution (km/h)}
 
 \item{bird}{A GeoPressureR \code{bird} object containing the basic morphological traits necessary:
 mass, wing span, wing aspect ratio, and body frontal area. See \code{bird_create()}.}
 
 \item{power2prob}{function taking power as a single argument and returning a probability}
 
-\item{low_speed_fix}{speed below which the probability remains the same. This parameter is used
-to allow short flights covering small distances.}
+\item{low_speed_fix}{speed below which the probability remains the same, i.e. we assign the same
+probability at \code{low_speed_fix} for any lower speed. This parameter is used to allow short
+flights covering small distances. (unit of km/h)}
+
+\item{zero_speed_ratio}{multiplicative ratio of the probability for speed zero. This ratio apply
+only when the bird is stayin at the same location (fly and come back or stay within pixel size).
+This parameter (when greater than 1) is used to favour a bird to stay at the same location rather
+than perform short fly.}
 }
 \value{
 Graph list with a new list \code{graph$movement} storing all the parameters needed to compute

--- a/man/plot.map.Rd
+++ b/man/plot.map.Rd
@@ -6,8 +6,8 @@
 \usage{
 \method{plot}{map}(
   x,
-  thr_likelihood = 1,
   path = NULL,
+  thr_likelihood = 1,
   plot_leaflet = TRUE,
   provider = "Esri.WorldTopoMap",
   provider_options = leaflet::providerTileOptions(),
@@ -21,9 +21,9 @@
 \arguments{
 \item{x}{a \code{\link[terra]{SpatRaster}} or a \code{RasterLayer} object--see \code{\link[raster]{raster}}}
 
-\item{thr_likelihood}{threshold of percentile (see details).}
-
 \item{path}{a GeoPressureR \code{path} data.frame}
+
+\item{thr_likelihood}{threshold of percentile (see details).}
 
 \item{plot_leaflet}{logical to use an interactive \code{leaflet} map instead of \code{terra::plot}}
 

--- a/man/plot_graph_movement.Rd
+++ b/man/plot_graph_movement.Rd
@@ -4,7 +4,7 @@
 \alias{plot_graph_movement}
 \title{Plot movement model of a \code{graph}}
 \usage{
-plot_graph_movement(graph, speed = seq(1, 120), plot_plotly = FALSE)
+plot_graph_movement(graph, speed = seq(0, 120), plot_plotly = FALSE)
 }
 \arguments{
 \item{graph}{a GeoPressureR \code{graph} object.}

--- a/man/tag_download_wind.Rd
+++ b/man/tag_download_wind.Rd
@@ -12,7 +12,9 @@ tag_download_wind(
   cds_token = Sys.getenv("cds_token"),
   file = function(stap_id)
     glue::glue("./data/wind/{tag$param$id}/{tag$param$id}_{stap_id}.nc"),
-  overwrite = FALSE
+  overwrite = FALSE,
+  workers = 19,
+  ...
 )
 }
 \arguments{
@@ -37,6 +39,24 @@ Default is to download all flights.}
 taking as single argument the stationary period identifier.}
 
 \item{overwrite}{logical. If \code{TRUE}, file is overwritten.}
+
+\item{workers}{maximum number of simultaneous request that will be submitted
+to the service. Most ECMWF services are limited to 20 concurrent requests
+(default = 2).}
+
+\item{...}{
+  Arguments passed on to \code{\link[ecmwfr:wf_request]{ecmwfr::wf_request_batch}}
+  \describe{
+    \item{\code{user}}{user (default = "ecmwf") provided by the ECMWF data service,
+used to retrieve the token set by \code{\link[ecmwfr]{wf_set_key}}}
+    \item{\code{path}}{path were to store the downloaded data}
+    \item{\code{time_out}}{how long to wait on a download to start (default =
+\code{3*3600} seconds).}
+    \item{\code{retry}}{polling frequency of submitted request for downloading (default =
+\code{30} seconds).}
+    \item{\code{request_list}}{a list of requests that will be processed in parallel.}
+    \item{\code{total_timeout}}{overall timeout limit for all the requests in seconds.}
+  }}
 }
 \value{
 the path of the downloaded (requested file) or the an R6 object with download/transfer


### PR DESCRIPTION
# GeoPressureR v3.3.2

## Major update
* Change the computation of distance of edges in the graph by removing the fix that added 1 resolution to the distance to account for large grid square and short flight distance. Instead, add warning message in case there might be such an issue (flight distance < grid resolution) [ddbd07d](https://github.com/Rafnuss/GeoPressureR/pull/126/commits/ddbd07db195440005f7f1ff96dd134dd43bdd8ae). 
* Add `zero_speed_threshold` parameter that allow to encourage bird to stay at the same location. This is typically the case for short flight that don't seems to affect the position. Quite similar to a `stap_elev` [2060790](https://github.com/Rafnuss/GeoPressureR/pull/126/commits/2060790f8508c447a00877c2fc1d86c9d52bfe2e)
* Add other type of pressurepath in interim [8d7f1d1](https://github.com/Rafnuss/GeoPressureR/pull/126/commits/8d7f1d12665608d37f5eafa53fb251554e7f5cdd)

## Minor
* Plenty of small fixes and minor improvements [834155e](https://github.com/Rafnuss/GeoPressureR/pull/126/commits/834155eeffcf04b33effce8d9b9d193c5554cbdf), [152c6e7](https://github.com/Rafnuss/GeoPressureR/pull/126/commits/152c6e7a2091970b444a47a3ceb0a367a42a9c2a), [54aa995](https://github.com/Rafnuss/GeoPressureR/pull/126/commits/54aa99589f8e709089a08ae02c5aace821ab7cea),  [3a5ff95](https://github.com/Rafnuss/GeoPressureR/pull/126/commits/3a5ff95774b353c853a32ed63327dad8df82fbbe), [6eedd83](https://github.com/Rafnuss/GeoPressureR/pull/126/commits/6eedd83802f9377db43cba06c2e4b684b2154452), [8797533](https://github.com/Rafnuss/GeoPressureR/pull/126/commits/8797533b49c9cc76a3d81a90824a8ceaabd48692), [1e68260](https://github.com/Rafnuss/GeoPressureR/pull/126/commits/1e68260c39bc49816c95095d0f3c3541986a50df)